### PR TITLE
fix PHP syntax error

### DIFF
--- a/dist/index.php
+++ b/dist/index.php
@@ -117,7 +117,7 @@ if($status=="OK"){
 </li>
 <?php endforeach; ?>
 </ul>
-<? endif ?>
+<?php endif ?>
 <h5>Error log</h5>
 <textarea id="log"><?php if(file_exists("log")){echo file_get_contents("log");} ?></textarea><br>
 &copy; <?php echo $config["copy"] ?> 2019<br>


### PR DESCRIPTION
This pull request fix "PHP Parse error: syntax error, unexpected end of file, expecting elseif (T_ELSEIF) or else (T_ELSE) or endif (T_ENDIF)".

Short open tag is deprecated now. So it should change to default open tag.